### PR TITLE
Fix newlines getting consumed by templating logic

### DIFF
--- a/supervise/templates/app.ini.j2
+++ b/supervise/templates/app.ini.j2
@@ -12,9 +12,11 @@ directory={{ chdir|replace("~", "%(ENV_HOME)s") }}
 stdout_logfile={{ log_dir|replace("~", "%(ENV_HOME)s") }}/{{ name }}.out.log
 stderr_logfile={{ log_dir|replace("~", "%(ENV_HOME)s") }}/{{ name }}.err.log
 autostart={% if autostart %}true{% else %}false{% endif %}
+
 numprocs={{ numprocs }}
 user={{ user }}
-{% if umask %}umask={{ umask }}{% endif %}
 {% if app_env|length > 0 %}
 environment={% for name, var in app_env.iteritems() %}{{ name|upper }}="{{ var|replace('~', '%(ENV_HOME)s') }}"{% if not loop.last %},{% endif%}{% endfor %}
 {% endif %}
+
+{% if umask %}umask={{ umask }}{% endif %}


### PR DESCRIPTION
Jinja is consuming the newlines after `{% endif %}` resulting in files looking like:

``` ini
autostart=truenumprocs=1
```

instead of:

``` ini
autostart=true
numprocs=1
```
