### PR TITLE
Be sure to quote variables if they contain equal signs

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -3,7 +3,7 @@
        version={{ supervisor_version }}
        virtualenv={{ supervisor_virtualenv }}
        use_mirrors=no
-       {% if pip_args %} extra_args={{ pip_args }} {% endif %}
+       {% if pip_args %} "extra_args={{ pip_args }}" {% endif %}
 
 - name: ensuring required supervisor directories
   file: path={{ item }}


### PR DESCRIPTION
Using ansible 1.9.2 and python 2.7.3 we get the following error when using eggsby.supervisor role:

```
A variable inserted a new parameter into the module args.
Be sure to quote variables if they contain equal signs (for example: "{{var}}").
```

Quoting fixes the error in our scenario.
