### PR TITLE
updates jinja conditional for optional pip args

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -3,7 +3,7 @@
        version={{ supervisor_version }}
        virtualenv={{ supervisor_virtualenv }}
        use_mirrors=no
-       {% if pip_args %} extra_args={{ pip_args }} {% endif %}
+       extra_args="{% if pip_args %}{{ pip_args }}{% endif %}"
 
 - name: ensuring required supervisor directories
   file: path={{ item }}


### PR DESCRIPTION
There's another pull request that does solve this syntax error, but I don't think it properly passes the pip_args if they do exist.  This one should resolve that issue...